### PR TITLE
Fixes Issue #37:

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -349,7 +349,7 @@
       if (data.avatarUrl) {
         card.find(".issue-assignee").css("background-image", "url('" + data.avatarUrl + "')");
       } else {
-        const initials = data.assignee.split(/ /).map(namePart => namePart[0].toUpperCase()).join('');
+        const initials = data.assignee.trim().split(/ /).map(namePart => namePart[0].toUpperCase()).join('');
         card.find(".issue-assignee").text(initials);
         card.find(".issue-assignee").css("background-color", textColor(initials));
       }


### PR DESCRIPTION
Added trim to the assignee before splitting up by space.
This avoids and TypeError with users that have a leading or trailing space within their name.
The spaces lead to an undefined object where an Array is expected by the filter