### PR TITLE
Fix links to bookmarklet.js

### DIFF
--- a/source-files/bookmarkInstallation.html
+++ b/source-files/bookmarkInstallation.html
@@ -47,12 +47,12 @@
     <p>Just Drag'n'Drop the button into your Bookmarks</p>
     </div>
     <div class="button">
-        <a href="javascript:(function()%7B var head %3D document.getElementsByTagName(%27head%27)%5B0%5D%3B var scriptElement %3D document.createElement(%27script%27)%3B scriptElement.src %3D %27http://localhost/bookmarklet.js%27%3B head.appendChild(scriptElement)%3B head.removeChild(scriptElement)%3B %7D)()%3B">IssueCardPrinter</a>
+        <a href="javascript:(function()%7B var head %3D document.getElementsByTagName(%27head%27)%5B0%5D%3B var scriptElement %3D document.createElement(%27script%27)%3B scriptElement.src %3D %27https://qoomon.github.io/Jira-Issue-Card-Printer/bookmarklet.js%27%3B head.appendChild(scriptElement)%3B head.removeChild(scriptElement)%3B %7D)()%3B">IssueCardPrinter</a>
     </div>
     <p>
     <b>Or create Bookmark with following content</b>
     <pre><code>
-javascript:(function(){var e=document.getElementsByTagName("head")[0],t=document.createElement("script");t.src="http://localhost/bookmarklet.js",e.appendChild(t),e.removeChild(t)})();
+javascript:(function(){var e=document.getElementsByTagName("head")[0],t=document.createElement("script");t.src="https://qoomon.github.io/Jira-Issue-Card-Printer/bookmarklet.js",e.appendChild(t),e.removeChild(t)})();
     </code></pre>
   </body>
 </html>


### PR DESCRIPTION
My last merge left in some local testing URLs.  These are now fixed.  Ideally we would alter GULP to fix this, but for now, the URL of the installation site is hardcoded into the bookmarklet installation HTML.